### PR TITLE
Update from debug_unreachable to new_debug_unreachable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "futf"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Keegan McAllister <kmcallister@mozilla.com>"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/futf"
@@ -9,4 +9,4 @@ description = "Handling fragments of UTF-8"
 
 [dependencies]
 mac = "0.1.0"
-debug_unreachable = "0.1.1"
+new_debug_unreachable = "1.0.0"


### PR DESCRIPTION
Because debug_unreachable doesn't work correctly on stable Rust 1.x.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/futf/8)
<!-- Reviewable:end -->
