### PR TITLE
Remove obsolete `str_char` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(test, feature(test, str_char))]
+#![cfg_attr(test, feature(test))]
 
 #[macro_use]
 extern crate debug_unreachable;


### PR DESCRIPTION
Fixes `cargo test` on modern versions of Rust

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/futf/10)
<!-- Reviewable:end -->
