### PR TITLE
Bump new_debug_unreachable to 1.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ description = "Handling fragments of UTF-8"
 
 [dependencies]
 mac = "0.1.0"
-new_debug_unreachable = "1.0.0"
+new_debug_unreachable = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "futf"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Keegan McAllister <kmcallister@mozilla.com>"]
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/futf"


### PR DESCRIPTION
Previous versions are incompatible with -Z minimal-versions builds. See also https://github.com/servo/string-cache/pull/253.